### PR TITLE
Update proconio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/main.rs"
 # AtCoder 2019年言語アップデート以降に使用できるクレート
 
 # 競技プログラミングの入出力サポート
-proconio = "=0.2.1"
+proconio = "=0.3.0"
+# proconio-derive = "=0.1.5"
 
 # f64のOrd/Eq実装
 # ordered-float = "=1.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use proconio::input;
 // ABC086C - Traveling
 // https://atcoder.jp/contests/abs/fasks/arc089_a
 
-#[proconio::fastout]
 fn main() {
     input! {
         n: usize,


### PR DESCRIPTION
proconio を 0.3.0 に上げ、依存しなくなった proconio_derive を再度追加します。またサンプルから #[fastout] の指定を削除します (AtCoder では出力の行数がさほど多くないことも多く、特に最初の方の問題では #[fastout] は不要と考えられるため) 。