### PR TITLE
Update proconio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,8 @@ dependencies = [
  "once_cell 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutohedron 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "proconio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proconio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proconio-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -390,11 +391,10 @@ dependencies = [
 
 [[package]]
 name = "proconio"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proconio-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -714,7 +714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum permutohedron 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b687ff7b5da449d39e418ad391e5e08da53ec334903ddbb921db208908fc372c"
 "checksum proc-macro-hack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1dd4172a1e1f96f709341418f49b11ea6c2d95d53dca08c0f74cbd332d9cf3"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proconio 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2aa8062d9da9155829b247cbfdb50e8867de06d3f2fa65008067743db6a923"
+"checksum proconio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be9f4a2df92cbf40e170078ca07aff564233a9e00f8c34573d4cf6bc50b4afcf"
 "checksum proconio-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cbe4b8993fb10674fbc95383266dbb57608642c389134495e5f485a54d19fe3f"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ path = "src/main.rs"
 # AtCoder 2019年言語アップデート以降に使用できるクレート
 
 # 競技プログラミングの入出力サポート
-proconio = "=0.2.1"
+proconio = "=0.3.0"
+proconio-derive = "=0.1.5"
 
 # f64のOrd/Eq実装
 ordered-float = "=1.0.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> UnitResult {
 // https://atcoder.jp/contests/abs/fasks/arc089_a
 
 // proconio
-#[proconio::fastout]
+#[proconio_derive::fastout]
 fn run_proconio() {
     use proconio::input;
     use proconio::source::auto::AutoSource;


### PR DESCRIPTION
proconio を 0.3.0 に上げ、依存しなくなった proconio_derive を再度追加します。