### PR TITLE
Fix test code in jamallocator

### DIFF
--- a/tests/test_jemallocator.rs
+++ b/tests/test_jemallocator.rs
@@ -25,7 +25,7 @@ fn do_allocate_heap() -> UnitResult {
 
     let mut rng = SmallRng::from_rng(thread_rng())?;
 
-    let v = rng
+    let v = (&mut rng)
         .sample_iter(&rand::distributions::Standard)
         .take(SIZE)
         .collect::<Vec<usize>>();


### PR DESCRIPTION
With the update of rand to 0.7, the test code of jemallocator needed to
be fixed, but the fix was missing in the commit.  This commit adds it.