### PR TITLE
Make the test of jemalloc optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2018"
 name = "main"
 path = "src/main.rs"
 
+[features]
+jemalloc = ["jemalloc-ctl", "jemallocator"]
+default = ["jemalloc"]
+
 [dependencies]
 # AtCoder 2019年言語アップデート以降に使用できるクレート
 
@@ -70,8 +74,14 @@ ndarray = "=0.12.1"
 nalgebra = "=0.18.1"
 
 # 代替ヒープアロケータ。条件によってはシステムアロケータより速いことも
-jemallocator = "=0.3.2"
-jemalloc-ctl = "=0.3.3"
+[target.'cfg(not(windows))'.dependencies]
+jemallocator = { version = "=0.3.2", optional = true }
+jemalloc-ctl = { version = "=0.3.3", optional = true }
+
+[[test]]
+name = "jemallocator"
+path = "tests/test_jemallocator.rs"
+required-features = ["jemalloc"]
 
 # ---------------------------------------------------------------------
 


### PR DESCRIPTION
Jemalloc は Windows (MSVC) ではサポートされていないため、現状 Windows でこれらのテストを実行するには一々 jemalloc 系の依存とテストを削除しなければなりません。これは面倒ですし、編集した Cargo.toml やテストの削除を誤ってコミットに含んでしまう危険性もあります。

本来ならば Unix 環境でだけこのテストを有効化できればよかったのですが、おそらく[このあたり](https://github.com/rust-lang/cargo/issues/1197)で議論はされているものの現状の解決はないように見えます。とりあえず jemalloc 関連の機能をフィーチャー `jemalloc` でまとめ、このフィーチャーが有効なときだけテストを実行することにしました。とはいえ実行を忘れてしまっても困るのでこれはデフォルトフィーチャーにしておきます。 Windows でテストする方がいらっしゃれば `cargo test --no-default-features` とすれば jemalloc を無視してテストをします。

より良い方法があればぜひお教えください。