### PR TITLE
Add `num-traits` to Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "permutohedron 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ default = ["jemalloc"]
 # 多バイト長整数、分数、複素数など
 num = "=0.2.0"
 num-derive = "=0.3.0"
+# num-derive が依存するため必要
+num-traits = "=0.2.9"
 
 # 多次元配列
 ndarray = "=0.13.0"

--- a/tests/test_num_derive.rs
+++ b/tests/test_num_derive.rs
@@ -2,22 +2,36 @@ use num_derive::{FromPrimitive, Num, NumCast, NumOps, One, ToPrimitive, Zero};
 
 #[derive(
     Debug,
-    Eq,
+    Clone,
+    Copy,
     PartialEq,
+    Eq,
     PartialOrd,
     Ord,
     FromPrimitive,
     ToPrimitive,
-    One,
     Zero,
+    One,
     Num,
     NumCast,
     NumOps,
 )]
 struct Weight(i32);
 
-fn main() {
-    let w1 = Weight(3);
+#[test]
+fn check_ops() {
+    let w1 = Weight(7);
     let w2 = Weight(4);
-    println!("{:?}", w1 + w2); // => "Weight(7)"
+
+    assert_eq!(w1 + w2, Weight(11));
+    assert_eq!(w1 - w2, Weight(3));
+    assert_eq!(w1 * w2, Weight(28));
+    assert_eq!(w1 / w2, Weight(1));
+    assert_eq!(w1 % w2, Weight(3));
+    assert!(w1 > w2);
+    assert!(w2 < w1);
+    assert!(w1 >= w1);
+    assert!(w1 <= w1);
+    assert!(w1 != w2);
+    assert!(w1 == w1);
 }

--- a/tests/test_num_derive.rs
+++ b/tests/test_num_derive.rs
@@ -1,0 +1,23 @@
+use num_derive::{FromPrimitive, Num, NumCast, NumOps, One, ToPrimitive, Zero};
+
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    FromPrimitive,
+    ToPrimitive,
+    One,
+    Zero,
+    Num,
+    NumCast,
+    NumOps,
+)]
+struct Weight(i32);
+
+fn main() {
+    let w1 = Weight(3);
+    let w2 = Weight(4);
+    println!("{:?}", w1 + w2); // => "Weight(7)"
+}


### PR DESCRIPTION
The `num-derive` requires `num-traits` to be explicitly included in
Cargo.toml.  (cf. https://github.com/rust-num/num-derive/issues/34)
This issue may be fixed in
https://github.com/rust-num/num-derive/pull/35.