### PR TITLE
Improve `dep-tests`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,56 +35,20 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: -- --check
 
-  dep-tests:
-    strategy:
-      fail-fast: false
-
-    name: dep-tests
-    runs-on: ubuntu-18.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v1
-
-      - name: rust-toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.38.0-x86_64-unknown-linux-gnu
-          override: true
-          profile: default
-
-      - name: '`cargo fmt --all --manifest-path ./dep-tests/Cargo.toml -- --check`'
+      - name: '`cargo fmt --manifest-path ./dep-tests/Cargo.toml -- --check`'
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all --manifest-path ./dep-tests/Cargo.toml -- --check
-
-      - name: '`cargo clippy --manifest-path ./dep-tests/Cargo.toml -- -D warnings`'
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --manifest-path ./dep-tests/Cargo.toml -- -D warnings
-
-      - name: '`cargo test --no-fail-fast --manifest-path ./dep-tests/Cargo.toml`'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast --manifest-path ./dep-tests/Cargo.toml
-
-      - name: '`cargo dep-tests --all-features -d 1`'
-        uses: actions-rs/cargo@v1
-        with:
-          command: dep-tests
-          args: --all-features -d 1
+          args: --manifest-path ./dep-tests/Cargo.toml -- --check
 
   build:
     strategy:
       fail-fast: false
       matrix:
         toolchain:
-          # `x86_64-pc-windows-msvc` is tier 1 **for now**.
+          # `x86_64-pc-windows-gnu` is tier 1 **for now**.
           - 1.38.0-x86_64-pc-windows-msvc
           - 1.38.0-x86_64-pc-windows-gnu
           - 1.38.0-x86_64-apple-darwin
@@ -99,28 +63,52 @@ jobs:
           - beta-x86_64-unknown-linux-gnu
         include:
           - toolchain: 1.38.0-x86_64-pc-windows-msvc
+            features: --no-default-features
+            dep_tests: true
             os: windows-latest
           - toolchain: 1.38.0-x86_64-pc-windows-gnu
+            features: --no-default-features
+            dep_tests: false
             os: windows-latest
           - toolchain: 1.38.0-x86_64-apple-darwin
+            features: --all-features
+            dep_tests: true
             os: macOS-latest
           - toolchain: 1.38.0-x86_64-unknown-linux-gnu
+            features: --all-features
+            dep_tests: true
             os: ubuntu-18.04
           - toolchain: stable-x86_64-pc-windows-msvc
+            features: --no-default-features
+            dep_tests: true
             os: windows-latest
           - toolchain: stable-x86_64-pc-windows-gnu
+            features: --no-default-features
+            dep_tests: false
             os: windows-latest
           - toolchain: stable-x86_64-apple-darwin
+            features: --all-features
+            dep_tests: true
             os: macOS-latest
           - toolchain: stable-x86_64-unknown-linux-gnu
+            features: --all-features
+            dep_tests: true
             os: ubuntu-18.04
           - toolchain: beta-x86_64-pc-windows-msvc
+            features: --no-default-features
+            dep_tests: true
             os: windows-latest
           - toolchain: beta-x86_64-pc-windows-gnu
+            features: --no-default-features
+            dep_tests: false
             os: windows-latest
           - toolchain: beta-x86_64-apple-darwin
+            features: --all-features
+            dep_tests: true
             os: macOS-latest
           - toolchain: beta-x86_64-unknown-linux-gnu
+            features: --all-features
+            dep_tests: true
             os: ubuntu-18.04
 
     name: ${{ matrix.toolchain }}
@@ -141,30 +129,41 @@ jobs:
           override: true
           profile: default
 
-      - name: Determine features
-        id: features
-        run: |
-          if ${{ matrix.os == 'windows-latest' }}; then
-            echo '::set-output name=features::--no-default-features'
-          else
-            echo '::set-output name=features::--all-features'
-          fi
-        shell: bash
-
-      - name: '`cargo clippy`'
+      - name: '`cargo clippy ${{ matrix.features }} -- -D warnings`'
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: ${{ steps.features.outputs.features }} -- -D warnings
+          args: ${{ matrix.features }} -- -D warnings
 
-      - name: '`cargo test`'
+      - name: '`cargo test ${{ matrix.features }} --no-fail-fast`'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ steps.features.outputs.features }} --no-fail-fast
+          args: ${{ matrix.features }} --no-fail-fast
 
       - name: '`cargo run --release`'
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: ${{ steps.features.outputs.features }} --release
+          args: ${{ matrix.features }} --release
+
+      - name: '`cargo clippy ${{ matrix.features }} --manifest-path ./dep-tests/Cargo.toml -- -D warnings`'
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: ${{ matrix.features }} --manifest-path ./dep-tests/Cargo.toml -- -D warnings
+        if: matrix.dep_tests
+
+      - name: '`cargo test ${{ matrix.features }} --manifest-path ./dep-tests/Cargo.toml --no-fail-fast`'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ${{ matrix.features }} --manifest-path ./dep-tests/Cargo.toml --no-fail-fast
+        if: matrix.dep_tests
+
+      - name: '`cargo dep-tests --all-features -d 1`'
+        uses: actions-rs/cargo@v1
+        with:
+          command: dep-tests
+          args: --all-features -d 1
+        if: matrix.dep_tests

--- a/dep-tests.toml
+++ b/dep-tests.toml
@@ -1,17 +1,25 @@
+# See `cargo help pkgid`
+
+# **`-p`, `--package`が指定されていないとき**、記述したSPECに対応するpackageを除外する。
 exclude = [
   "c2-chacha:0.2.3",       # よくわからない理由でビルドに失敗する
   "derive_more:0.99.2",    # 必要なファイルがexcludeされている
-  "jemallocator:0.3.2",    # よくわからない理由でビルドに失敗する
   "libm:0.1.4",            # `#![deny(warnings)]`
   "mac:0.1.1",             # `#![deny(warnings)]`
   "nom:5.0.1",             # 必要なファイルがexcludeされている
   "num-rational:0.2.2",    # よくわからない理由でビルドに失敗する
-  "petgraph:0.4.13",       # よくわからない理由で実行時に失敗する
-  "primal:0.2.3",          # 最終リリース日が古すぎて"normalizing"が行なわれておらず、workspace membersが相対パスのまま
-  "primal-estimate:0.2.1", # 最終リリース日が古すぎて"normalizing"が行なわれておらず、workspace membersが相対パスのまま
+  "primal-estimate:0.2.1", # 古すぎて"normalizing"が行なわれておらず、workspace membersが相対パスのまま
+  "primal:0.2.3",          # 古すぎて"normalizing"が行なわれておらず、workspace membersが相対パスのまま
   "proc-macro2:1.0.6",     # よくわからない理由でビルドに失敗する
+  "rand:0.6.5",            # 現状同一の`name`のpackageは一つのworkspace内で共存できない
   "rand_core:0.3.1",       # よくわからない理由でビルドに失敗する
-  # "smallvec:1.0.0",       # 成功はするが謎のエラーが表示される
+  "rand_pcg:0.1.2",        # 現状同一の`name`のpackageは一つのworkspace内で共存できない
   "syn:0.15.44",           # よくわからない理由でビルドに失敗する
   "syn:1.0.8",             # よくわからない理由でビルドに失敗する
+  "smallvec:0.6.13",       # 現状同一の`name`のpackageは一つのworkspace内で共存できない
 ]
+
+# key部分でSPECを指定すると、そのSPECの対象のpackageはvalue部分で指定したtargetのみ実行する。
+[filter]
+"smallvec:1.0.0" = { lib = true }                                            # doc-testでエラーが表示され、成功はするしおそらく実害は無いが見た目がよろしくない
+"text_io:0.1.7" = { doc = true, lib = true, test = ["module", "read_str"] }  # `"tuple"`が`target/`下の実行ファイルを実行(しかもexamplesの)という行儀の悪いことをやっている

--- a/dep-tests/Cargo.toml
+++ b/dep-tests/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 cargo = "0.40.0"
+either = "1.5.3"
 failure = "0.1.6"
 fs_extra = "1.1.0"
 itertools = "0.8.2"
@@ -16,3 +17,4 @@ once_cell = "1.2.0"
 serde = { version = "1.0.103", features = ["derive"] }
 structopt = "0.3.5"
 toml = "0.5.5"
+toml_edit = "0.1.5"


### PR DESCRIPTION
ビルド時間を激増させてまでworkspaceを分割する理由はない気がしたので1つのworkspaceに押し込めるようにしました。というのも余計なpackageが追加されて起こるのは
1. 同一の名前のpackageはworkspace memberとしては複数共存できない
2. 既存packageのminor, patch versionの増加
3. 既存packageのfeatureが有効化されてしまう
で1.は適当に除外すれば良く、2.は`cargo update`をしてれば良いので。 また3.の影響もあまり大きくないと思います。

- `--skip <N>`を削除
- `dep-tests.toml`に ~~`exclude.tests`を追加し、target単位でexcludeできるように~~ `filter`を追加し、特定のtargetを除いてテストできるように
- dep-dependencyが無いやつは`atcoder-rust-base`からそのまま実行

具体的にはこんなworkspaceが生成されます。

```toml
[package]
name = "atcoder-rust-base-dep-tests"
version = "0.0.0"
edition = "2018"
publish = false

[workspace]
members = ["./aho-corasick-0.7.6", "./alga-0.9.2", "./bitset-fixed-0.1.0", "./euclid-0.20.4", "./im-rc-14.0.0", "./indexmap-1.3.0", "./itertools-0.8.1", "./itertools-num-0.1.3", "./lazy_static-1.4.0", "./libm-0.2.0", "./modtype-0.7.0", "./nalgebra-0.19.0", "./ndarray-0.13.0", "./num-derive-0.3.0", "./ordered-float-1.0.2", "./rand-0.7.2", "./rand_distr-0.2.2", "./rand_pcg-0.2.1", "./regex-1.3.1", "./smallvec-1.0.0", "./superslice-1.0.0", "./whiteread-0.4.4"]

[patch.crates-io]
aho-corasick = {path = "./aho-corasick-0.7.6"}
alga = {path = "./alga-0.9.2"}
bitset-fixed = {path = "./bitset-fixed-0.1.0"}
euclid = {path = "./euclid-0.20.4"}
im-rc = {path = "./im-rc-14.0.0"}
indexmap = {path = "./indexmap-1.3.0"}
itertools = {path = "./itertools-0.8.1"}
itertools-num = {path = "./itertools-num-0.1.3"}
lazy_static = {path = "./lazy_static-1.4.0"}
libm = {path = "./libm-0.2.0"}
modtype = {path = "./modtype-0.7.0"}
nalgebra = {path = "./nalgebra-0.19.0"}
ndarray = {path = "./ndarray-0.13.0"}
num-derive = {path = "./num-derive-0.3.0"}
ordered-float = {path = "./ordered-float-1.0.2"}
rand = {path = "./rand-0.7.2"}
rand_distr = {path = "./rand_distr-0.2.2"}
rand_pcg = {path = "./rand_pcg-0.2.1"}
regex = {path = "./regex-1.3.1"}
smallvec = {path = "./smallvec-1.0.0"}
superslice = {path = "./superslice-1.0.0"}
whiteread = {path = "./whiteread-0.4.4"}

[dependencies]
_0 = {package = "aho-corasick",path = "./aho-corasick-0.7.6",default-features = false,features = ["default", "std"]}
_1 = {package = "alga",path = "./alga-0.9.2",default-features = false,features = ["default", "std"]}
_2 = {package = "approx",version = "=0.3.2",default-features = false,features = ["default", "std"]}
_3 = {package = "arrayvec",version = "=0.4.12",default-features = false,features = ["array-sizes-33-128", "default", "std"]}
_4 = {package = "ascii",version = "=1.0.0",default-features = false,features = ["default", "std"]}
_5 = {package = "autocfg",version = "=0.1.7",default-features = false,features = []}
_6 = {package = "bitmaps",version = "=2.0.0",default-features = false,features = []}
_7 = {package = "bitset-fixed",path = "./bitset-fixed-0.1.0",default-features = false,features = []}
_8 = {package = "byteorder",version = "=1.3.2",default-features = false,features = ["default", "std"]}
_9 = {package = "c2-chacha",version = "=0.2.3",default-features = false,features = ["simd", "std"]}
_10 = {package = "cfg-if",version = "=0.1.10",default-features = false,features = []}
_11 = {package = "defmac",version = "=0.2.1",default-features = false,features = []}
_12 = {package = "derive-new",version = "=0.5.8",default-features = false,features = ["default", "std"]}
_13 = {package = "derive_more",version = "=0.99.2",default-features = false,features = ["add", "add_assign", "as_mut", "as_ref", "constructor", "default", "deref", "deref_mut", "display", "from", "from_str", "index", "index_mut", "into", "into_iterator", "iterator", "mul", "mul_assign", "not", "sum", "try_into"]}
_14 = {package = "either",version = "=1.5.3",default-features = false,features = ["default", "use_std"]}
_15 = {package = "euclid",path = "./euclid-0.20.4",default-features = false,features = []}
_16 = {package = "fixedbitset",version = "=0.1.9",default-features = false,features = []}
_17 = {package = "fixedbitset",version = "=0.2.0",default-features = false,features = ["default", "std"]}
_18 = {package = "generic-array",version = "=0.13.2",default-features = false,features = []}
_19 = {package = "getrandom",version = "=0.1.13",default-features = false,features = ["std"]}
_20 = {package = "hamming",version = "=0.1.3",default-features = false,features = []}
_21 = {package = "heck",version = "=0.3.1",default-features = false,features = []}
_22 = {package = "if_chain",version = "=1.0.0",default-features = false,features = []}
_23 = {package = "im-rc",path = "./im-rc-14.0.0",default-features = false,features = []}
_24 = {package = "indexmap",path = "./indexmap-1.3.0",default-features = false,features = []}
_25 = {package = "itertools",path = "./itertools-0.8.1",default-features = false,features = ["default", "use_std"]}
_26 = {package = "itertools-num",path = "./itertools-num-0.1.3",default-features = false,features = []}
_27 = {package = "lazy_static",path = "./lazy_static-1.4.0",default-features = false,features = []}
_28 = {package = "lexical-core",version = "=0.4.6",default-features = false,features = ["arrayvec", "correct", "default", "ryu", "std", "table"]}
_29 = {package = "libc",version = "=0.2.65",default-features = false,features = ["default", "std"]}
_30 = {package = "libm",version = "=0.1.4",default-features = false,features = ["default", "stable"]}
_31 = {package = "libm",path = "./libm-0.2.0",default-features = false,features = ["default"]}
_32 = {package = "mac",version = "=0.1.1",default-features = false,features = []}
_33 = {package = "maplit",version = "=1.0.2",default-features = false,features = []}
_34 = {package = "matrixmultiply",version = "=0.2.3",default-features = false,features = []}
_35 = {package = "maybe-uninit",version = "=2.0.0",default-features = false,features = []}
_36 = {package = "memchr",version = "=2.2.1",default-features = false,features = ["default", "use_std"]}
_37 = {package = "modtype",path = "./modtype-0.7.0",default-features = false,features = []}
_38 = {package = "modtype_derive",version = "=0.7.0",default-features = false,features = []}
_39 = {package = "nalgebra",path = "./nalgebra-0.19.0",default-features = false,features = ["default", "matrixmultiply", "rand_distr", "std"]}
_40 = {package = "ndarray",path = "./ndarray-0.13.0",default-features = false,features = []}
_41 = {package = "nodrop",version = "=0.1.14",default-features = false,features = []}
_42 = {package = "nom",version = "=5.0.1",default-features = false,features = ["alloc", "default", "lexical", "lexical-core", "std"]}
_43 = {package = "num",version = "=0.2.0",default-features = false,features = ["default", "num-bigint", "std"]}
_44 = {package = "num-bigint",version = "=0.2.3",default-features = false,features = ["default", "std"]}
_45 = {package = "num-complex",version = "=0.2.3",default-features = false,features = ["default", "std"]}
_46 = {package = "num-derive",path = "./num-derive-0.3.0",default-features = false,features = []}
_47 = {package = "num-integer",version = "=0.1.41",default-features = false,features = ["default", "std"]}
_48 = {package = "num-iter",version = "=0.1.39",default-features = false,features = ["std"]}
_49 = {package = "num-rational",version = "=0.2.2",default-features = false,features = ["bigint", "num-bigint", "std"]}
_50 = {package = "num-traits",version = "=0.2.9",default-features = false,features = ["default", "std"]}
_51 = {package = "ordered-float",path = "./ordered-float-1.0.2",default-features = false,features = ["default", "std"]}
_52 = {package = "ordermap",version = "=0.3.5",default-features = false,features = []}
_53 = {package = "permutohedron",version = "=0.2.4",default-features = false,features = ["default", "std"]}
_54 = {package = "petgraph",version = "=0.4.13",default-features = false,features = ["default", "graphmap", "ordermap", "stable_graph"]}
_55 = {package = "ppv-lite86",version = "=0.2.6",default-features = false,features = ["simd", "std"]}
_56 = {package = "primal",version = "=0.2.3",default-features = false,features = []}
_57 = {package = "primal-bit",version = "=0.2.4",default-features = false,features = []}
_58 = {package = "primal-check",version = "=0.2.3",default-features = false,features = []}
_59 = {package = "primal-estimate",version = "=0.2.1",default-features = false,features = []}
_60 = {package = "primal-sieve",version = "=0.2.9",default-features = false,features = []}
_61 = {package = "proc-macro2",version = "=0.4.30",default-features = false,features = ["default", "proc-macro"]}
_62 = {package = "proc-macro2",version = "=1.0.6",default-features = false,features = ["default", "proc-macro"]}
_63 = {package = "proconio",version = "=0.3.4",default-features = false,features = ["derive", "proconio-derive"]}
_64 = {package = "proconio-derive",version = "=0.1.5",default-features = false,features = []}
_65 = {package = "quote",version = "=0.6.13",default-features = false,features = ["default", "proc-macro"]}
_66 = {package = "quote",version = "=1.0.2",default-features = false,features = ["default", "proc-macro"]}
_67 = {package = "rand",version = "=0.6.5",default-features = false,features = ["alloc", "default", "rand_os", "std"]}
_68 = {package = "rand",path = "./rand-0.7.2",default-features = false,features = ["alloc", "default", "getrandom", "getrandom_package", "rand_pcg", "small_rng", "std"]}
_69 = {package = "rand_chacha",version = "=0.1.1",default-features = false,features = []}
_70 = {package = "rand_chacha",version = "=0.2.1",default-features = false,features = ["default", "simd", "std"]}
_71 = {package = "rand_core",version = "=0.3.1",default-features = false,features = []}
_72 = {package = "rand_core",version = "=0.4.2",default-features = false,features = ["alloc", "std"]}
_73 = {package = "rand_core",version = "=0.5.1",default-features = false,features = ["alloc", "getrandom", "std"]}
_74 = {package = "rand_distr",path = "./rand_distr-0.2.2",default-features = false,features = []}
_75 = {package = "rand_hc",version = "=0.1.0",default-features = false,features = []}
_76 = {package = "rand_isaac",version = "=0.1.1",default-features = false,features = []}
_77 = {package = "rand_jitter",version = "=0.1.4",default-features = false,features = ["std"]}
_78 = {package = "rand_os",version = "=0.1.3",default-features = false,features = []}
_79 = {package = "rand_pcg",version = "=0.1.2",default-features = false,features = []}
_80 = {package = "rand_pcg",path = "./rand_pcg-0.2.1",default-features = false,features = []}
_81 = {package = "rand_xorshift",version = "=0.1.1",default-features = false,features = []}
_82 = {package = "rand_xoshiro",version = "=0.4.0",default-features = false,features = []}
_83 = {package = "rawpointer",version = "=0.2.1",default-features = false,features = []}
_84 = {package = "regex",path = "./regex-1.3.1",default-features = false,features = ["aho-corasick", "default", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "thread_local", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]}
_85 = {package = "regex-syntax",version = "=0.6.12",default-features = false,features = ["unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]}
_86 = {package = "rustc-hash",version = "=1.0.1",default-features = false,features = []}
_87 = {package = "rustc_version",version = "=0.2.3",default-features = false,features = []}
_88 = {package = "ryu",version = "=1.0.2",default-features = false,features = []}
_89 = {package = "semver",version = "=0.9.0",default-features = false,features = ["default"]}
_90 = {package = "semver-parser",version = "=0.7.0",default-features = false,features = []}
_91 = {package = "sized-chunks",version = "=0.5.0",default-features = false,features = []}
_92 = {package = "smallvec",version = "=0.6.13",default-features = false,features = ["default", "std"]}
_93 = {package = "smallvec",path = "./smallvec-1.0.0",default-features = false,features = []}
_94 = {package = "static_assertions",version = "=0.3.4",default-features = false,features = []}
_95 = {package = "strsim",version = "=0.9.2",default-features = false,features = []}
_96 = {package = "superslice",path = "./superslice-1.0.0",default-features = false,features = []}
_97 = {package = "syn",version = "=0.15.44",default-features = false,features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote"]}
_98 = {package = "syn",version = "=1.0.8",default-features = false,features = ["clone-impls", "default", "derive", "extra-traits", "parsing", "printing", "proc-macro", "quote"]}
_99 = {package = "take_mut",version = "=0.2.2",default-features = false,features = []}
_100 = {package = "text_io",version = "=0.1.7",default-features = false,features = []}
_101 = {package = "thread_local",version = "=0.3.6",default-features = false,features = []}
_102 = {package = "typenum",version = "=1.11.2",default-features = false,features = []}
_103 = {package = "unicode-segmentation",version = "=1.6.0",default-features = false,features = []}
_104 = {package = "unicode-xid",version = "=0.1.0",default-features = false,features = ["default"]}
_105 = {package = "unicode-xid",version = "=0.2.0",default-features = false,features = ["default"]}
_106 = {package = "version_check",version = "=0.1.5",default-features = false,features = []}
_107 = {package = "version_check",version = "=0.9.1",default-features = false,features = []}
_108 = {package = "whiteread",path = "./whiteread-0.4.4",default-features = false,features = []}
```