### PR TITLE
`codegen-units = 1` and `incremental = false`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,10 @@ name = "atcoder-rust-base"
 version = "0.1.0"
 edition = "2018"
 
+[profile.release]
+codegen-units = 1
+incremental = false
+
 [workspace]
 exclude = ["./tools"]
 


### PR DESCRIPTION
[Playgroundのよう](https://github.com/integer32llc/rust-playground/blob/ed8386a72a9919e9b823c2fd2e6cf937d0c809a2/compiler/base/Cargo.toml#L9-L11)に最終的バイナリのパフォーマンスを向上させる設定をします。

`main.rs`のコンパイル速度には影響を与えないはずです。

また`dep-option-generator`で構成されたコンパイルオプションは元から`-C incremental=..`を使っていないので『本物のコンパイルオプション』との差異が小さくなるという効果もあります。