### PR TITLE
Add more examples

### DIFF
--- a/examples/abc169-c.rs
+++ b/examples/abc169-c.rs
@@ -1,0 +1,33 @@
+// https://atcoder.jp/contests/abc169/tasks/abc169_c
+//
+// 以下のクレートを使用。
+// - `num`
+//     - `num-rational`
+// - `proconio`
+
+use num::rational::Ratio;
+use proconio::input;
+
+// 有理数型である[`num_rational::Ratio<_>`]を使う。
+//
+// `Ratio<T>`に対する`FromStr`は`"Tの形式"`または`"Tの形式/Tの形式"`を受け付ける。
+// よって入力をパースするときはAはそのまま、
+// Bは小数点下が2桁で固定なので`(_.replace('.', "") + "/100").parse().unwrap()`とすれば良い。
+//
+// そして[`.to_integer()`]で「0方向に丸めた整数」が得られるので`(_ * _).to_integer()`を答えとすれば良い。
+//
+// [`num_rational::Ratio<_>`]: https://docs.rs/num-rational/0.2.4/num_rational/struct.Ratio.html
+// [`.to_integer()`]: https://docs.rs/num-rational/0.2.4/num_rational/struct.Ratio.html#method.to_integer
+
+fn main() {
+    // [`proconio::input!`]で入力を読む。
+    //
+    // [`proconio::input!`]: https://docs.rs/proconio/0.3.6/proconio/macro.input.html
+    input! {
+        a: Ratio<u64>,
+        b: String,
+    }
+
+    let b = (b.replace('.', "") + "/100").parse::<Ratio<_>>().unwrap();
+    println!("{}", (a * b).to_integer());
+}

--- a/examples/tokiomarine2020-a.rs
+++ b/examples/tokiomarine2020-a.rs
@@ -25,8 +25,9 @@ fn main() {
     //
     // `ascii`クレートを使わずに行うなら、
     //
-    // 1. Sを`String`として読み、`s.chars().take(3).collect::<String>()`
-    // 2. Sを[`proconio::marker::Bytes`]経由で`Vec<u8>`として読み(あるいは`String`から`.into_bytes()`する)、`std::str::from_utf8(&s[..3]).unwrap()`
+    // 1. Sを`String`として読み、`&s[..3]`としてスライスを取得する
+    // 2. Sを`String`として読み、`s.chars().take(3).collect::<String>()`
+    // 3. Sを[`proconio::marker::Bytes`]経由で`Vec<u8>`として読み(あるいは`String`から`.into_bytes()`する)、`std::str::from_utf8(&s[..3]).unwrap()`
     //
     // の2つの方法がある。
     //

--- a/examples/tokiomarine2020-a.rs
+++ b/examples/tokiomarine2020-a.rs
@@ -1,0 +1,38 @@
+// https://atcoder.jp/contests/tokiomarine2020/tasks/tokiomarine2020_a
+//
+// 以下のクレートを使用。
+// - `ascii`
+// - `proconio`
+
+use ascii::AsciiString;
+use proconio::input;
+
+fn main() {
+    // Sを[`ascii::AsciiString`]として、[`proconio::input!`]で入力を読む。
+    //
+    // [`ascii::AsciiString`]: https://docs.rs/ascii/1.0.0/ascii/struct.AsciiString.html
+    // [`proconio::input!`]:   https://docs.rs/proconio/0.3.6/proconio/macro.input.html
+    input! {
+        s: AsciiString,
+    }
+
+    // [`AsciiStr`] / `AsciiString`は
+    //
+    // 1. [`usize`の範囲でアクセス可能]であり**かつ**
+    // 2. そのまま[`Display`]可能
+    //
+    // であることから、このような問題で変換を挟まずに簡潔に書くことができる。
+    //
+    // `ascii`クレートを使わずに行うなら、
+    //
+    // 1. Sを`String`として読み、`s.chars().take(3).collect::<String>()`
+    // 2. Sを[`proconio::marker::Bytes`]経由で`Vec<u8>`として読み(あるいは`String`から`.into_bytes()`する)、`std::str::from_utf8(&s[..3]).unwrap()`
+    //
+    // の2つの方法がある。
+    //
+    // [`AsciiStr`]:                  https://docs.rs/ascii/1.0.0/ascii/struct.AsciiStr.html
+    // [`usize`の範囲でアクセス可能]: https://docs.rs/ascii/1.0.0/ascii/struct.AsciiStr.html#impl-Index%3CRangeTo%3Cusize%3E%3E
+    // [`Display`]:                   https://doc.rust-lang.org/1.42.0/std/fmt/trait.Display.html
+    // [`proconio::marker::Bytes`]:   https://docs.rs/proconio/0.3.6/proconio/marker/enum.Bytes.html
+    println!("{}", &s[..3]);
+}

--- a/examples/tokiomarine2020-c.rs
+++ b/examples/tokiomarine2020-c.rs
@@ -1,0 +1,51 @@
+// https://atcoder.jp/contests/tokiomarine2020/tasks/tokiomarine2020_a
+//
+// 以下のクレートを使用。
+// - `itertools`
+// - `itertools-num`
+// - `proconio`
+
+use itertools::Itertools as _;
+use itertools_num::ItertoolsNum as _;
+use proconio::input;
+use std::cmp;
+
+fn main() {
+    // [`proconio::input!`]で入力を読む。
+    //
+    // [`proconio::input!`]: https://docs.rs/proconio/0.3.6/proconio/macro.input.html
+    input! {
+        n: usize,
+        k: usize,
+        mut r#as: [usize; n],
+    }
+
+    for _ in 0..k {
+        // NもAも`usize`で持っておけば、numeric castは一箇所で済む。
+
+        let mut imos = vec![0; n + 1];
+
+        for (i, &a) in r#as.iter().enumerate() {
+            let l = i.saturating_sub(a);
+            let r = cmp::min(i + a + 1, n);
+            imos[l] += 1;
+            imos[r] -= 1;
+        }
+
+        // [`itertools_num::ItertoolsNum::cumsom`]を使って`imos`を復元する。
+        //
+        // [`itertools_num::ItertoolsNum::cumsom`]:  https://docs.rs/itertools-num/0.1.3/itertools_num/trait.ItertoolsNum.html#method.cumsum
+        r#as = imos[..n].iter().map(|&x| x as usize).cumsum().collect();
+
+        if r#as.iter().all(|&a| a == n) {
+            break;
+        }
+    }
+
+    // [`itertools::Itertools::format`]でスペース区切りにしたものを`println!`する。
+    //
+    // 注意としてこのメソッドの返り値はイテレータを`RefCell<Option<_>>`の形で保持していており、二度displayしようとするとpanicする。
+    //
+    // [`itertools::Itertools::format`]: https://docs.rs/itertools/0.9.0/itertools/trait.Itertools.html#method.format
+    println!("{}", r#as.into_iter().format(" "));
+}

--- a/test-examples.toml
+++ b/test-examples.toml
@@ -475,3 +475,17 @@ name = "Sumitomo Mitsui Trust Bank Programming Contest 2019: C - 100 to 105"
 url = "https://atcoder.jp/contests/sumitrust2019/tasks/sumitb2019_c"
 matching = "Words"
 meta = { using = ["fixedbitset", "proconio"] }
+
+[examples.tokiomarine2020-a]
+type = "Normal"
+name = "Tokio Marine & Nichido Fire Insurance Programming Contest 2020: A - Nickname"
+url = "https://atcoder.jp/contests/tokiomarine2020/tasks/tokiomarine2020_a"
+matching = "Words"
+meta = { using = ["ascii", "proconio"] }
+
+[examples.tokiomarine2020-c]
+type = "Normal"
+name = "Tokio Marine & Nichido Fire Insurance Programming Contest 2020: C - Lamps"
+url = "https://atcoder.jp/contests/tokiomarine2020/tasks/tokiomarine2020_c"
+matching = "Words"
+meta = { using = ["itertools", "itertools-num", "proconio"] }

--- a/test-examples.toml
+++ b/test-examples.toml
@@ -275,6 +275,13 @@ url = "https://atcoder.jp/contests/abc168/tasks/abc168_e"
 matching = "Words"
 meta = { using = ["maplit", "num", "proconio"] }
 
+[examples.abc169-c]
+type = "Normal"
+name = "ABC169 - C - Multiplication 3"
+url = "https://atcoder.jp/contests/abc169/tasks/abc169_c"
+matching = "Words"
+meta = { using = ["num", "proconio"] }
+
 [examples.agc020-c]
 type = "Normal"
 name = "AGC020: C - Median Sum"


### PR DESCRIPTION
[ABC169 - C - Multiplication 3](https://atcoder.jp/contests/abc169/tasks/abc169_c)

[`num_rational::Ratio`](https://docs.rs/num-rational/0.2.4/num_rational/struct.Ratio.html)を使う。

Bは小数点下が2桁で固定なので`(_.replace('.', "") + "/100").parse().unwrap()`としてパースできる。 そして後は何も考えずに`(a * b).to_integer()`を答えとすれば良い。

