### PR TITLE
Ignore README.md

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+ignore = ["README.md"]


### PR DESCRIPTION
以下のコマンドを実行してプロジェクトを生成しようとすると、

```
$ cargo generate --name abc086c \
    --git https://github.com/rust-lang-ja/atcoder-rust-base \
    --branch ja
```

生成されるプロジェクトにこの[README.md](https://github.com/rust-lang-ja/atcoder-rust-base/tree/ja#readme)が含まれてしまいます。

しかし、ユーザーにとってはこのREADMEは生成したプロジェクト中に含まれて欲しくないはずなので、cargo generate実行時にREADME.mdが除外されるようにしました。